### PR TITLE
Iter1

### DIFF
--- a/.github/workflows/mertricstest.yml
+++ b/.github/workflows/mertricstest.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - iter1
 
 jobs:
 

--- a/.github/workflows/mertricstest.yml
+++ b/.github/workflows/mertricstest.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - iter1
 
 jobs:
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,20 +51,20 @@ func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Requ
 
 	res.Header().Set("Content-Type", "text/plain")
 
-	parcedUrl := strings.Split(req.URL.Path, "/")
-	if len(parcedUrl) < 5 {
+	parcedURL := strings.Split(req.URL.Path, "/")
+	if len(parcedURL) < 5 {
 		http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusNotFound)
 		return
-	} else if parcedUrl[1] != "update" {
-		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedUrl[2], http.StatusNotFound)
+	} else if parcedURL[1] != "update" {
+		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedURL[2], http.StatusNotFound)
 		return
-	} else if len(parcedUrl) == 6 && parcedUrl[6] != "" || len(parcedUrl) > 6 {
+	} else if len(parcedURL) == 6 && parcedURL[6] != "" || len(parcedURL) > 6 {
 		http.Error(res, "Невозможно обновить метрику(слишком много параметров)", http.StatusNotFound)
 	}
 
-	metricType := parcedUrl[2]
-	metricName := parcedUrl[3]
-	metricValue := parcedUrl[4]
+	metricType := parcedURL[2]
+	metricName := parcedURL[3]
+	metricValue := parcedURL[4]
 
 	if metricName == "" || metricValue == "" {
 		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,117 @@
 package main
 
-func main() {}
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type MemStorage struct {
+	gauge   map[string]float64
+	counter map[string]int64
+}
+
+func NewMemStorage() *MemStorage {
+	return &MemStorage{
+		gauge:   make(map[string]float64),
+		counter: make(map[string]int64),
+	}
+}
+
+func (ms *MemStorage) SetGauge(key string, value float64) {
+	ms.gauge[key] = value
+}
+
+func (ms *MemStorage) StrValueToFloat(str string) (value float64, err error) {
+	value, err = strconv.ParseFloat(str, 64)
+	return
+}
+
+func (ms *MemStorage) StrValueToInt(str string) (value int64, err error) {
+	value, err = strconv.ParseInt(str, 10, 64)
+	return
+}
+
+func (ms *MemStorage) SetCounter(key string, value int64) {
+	_, ok := ms.counter[key]
+	if ok {
+		ms.counter[key] += value
+
+	} else {
+		ms.counter[key] = value
+	}
+}
+
+func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		// http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusMethodNotAllowed)
+		res.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	res.Header().Set("Content-Type", "text/plain")
+
+	parcedUrl := strings.Split(req.URL.Path, "/")
+	if len(parcedUrl) < 5 {
+		http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusNotFound)
+		return
+	} else if parcedUrl[1] != "update" {
+		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedUrl[2], http.StatusNotFound)
+		return
+	} else if len(parcedUrl) == 6 && parcedUrl[6] != "" || len(parcedUrl) > 6 {
+		http.Error(res, "Невозможно обновить метрику(слишком много параметров)", http.StatusNotFound)
+	}
+
+	metricType := parcedUrl[2]
+	metricName := parcedUrl[3]
+	metricValue := parcedUrl[4]
+
+	if metricName == "" || metricValue == "" {
+		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
+		return
+	}
+
+	switch metricType {
+	case "gauge":
+		gaugeValue, err := ms.StrValueToFloat(metricValue)
+		if err != nil {
+			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
+			return
+		}
+		ms.SetGauge(metricName, gaugeValue)
+
+	case "counter":
+		counterValue, err := ms.StrValueToInt(metricValue)
+		if err != nil {
+			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
+			return
+		}
+		ms.SetCounter(metricName, counterValue)
+
+	default:
+		http.Error(res, "Неверный формат для обновления метрик (неверное имя)", http.StatusBadRequest)
+		return
+	}
+
+	res.WriteHeader(http.StatusOK)
+
+}
+
+func handleBasic(res http.ResponseWriter, req *http.Request) {
+	http.Error(res, "Неверная ссылка для обновления метрики", http.StatusNotFound)
+}
+
+func main() {
+
+	memStorage := NewMemStorage()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(`/update/`, memStorage.handleMetricUpdate)
+	mux.HandleFunc(`//`, memStorage.handleMetricUpdate)
+	mux.HandleFunc(`/`, handleBasic)
+
+	err := http.ListenAndServe(`:8080`, mux)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/maryakotova/metrics
+
+go 1.23.3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/maryakotova/metrics
 
-go 1.23.3
+go 1.22.10


### PR DESCRIPTION
Начальный вариант сервера для сбора рантайм-метрик, который будет собирать репорты от агентов по протоколу HTTP. 
Принимает данные в формате http://<АДРЕС_СЕРВЕРА>/update/<ТИП_МЕТРИКИ>/<ИМЯ_МЕТРИКИ>/<ЗНАЧЕНИЕ_МЕТРИКИ>, Content-Type: text/plain.
При успешном приёме возвращать http.StatusOK.
При попытке передать запрос без имени метрики возвращать http.StatusNotFound.
При попытке передать запрос с некорректным типом метрики или значением возвращать http.StatusBadRequest.
