### PR TITLE
Iter4

### DIFF
--- a/.github/workflows/mertricstest.yml
+++ b/.github/workflows/mertricstest.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - iter1
 
 jobs:
 

--- a/.github/workflows/mertricstest.yml
+++ b/.github/workflows/mertricstest.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - iter1
 
 jobs:
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,3 +1,124 @@
 package main
 
-func main() {}
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+const (
+	pollInterval   int64 = 2
+	reportInterval int64 = 10
+)
+
+var pollCont int64 = 0
+
+func collectMetrics() map[string]interface{} {
+	memStats := new(runtime.MemStats)
+	runtime.ReadMemStats(memStats)
+
+	metrics := make(map[string]interface{})
+
+	metrics["Alloc"] = memStats.Alloc
+	metrics["BuckHashSys"] = memStats.BuckHashSys
+	metrics["Frees"] = memStats.Frees
+	metrics["GCCPUFraction"] = memStats.GCCPUFraction
+	metrics["GCSys"] = memStats.GCSys
+	metrics["HeapAlloc"] = memStats.HeapAlloc
+	metrics["HeapIdle"] = memStats.HeapIdle
+	metrics["HeapInuse"] = memStats.HeapInuse
+	metrics["HeapObjects"] = memStats.HeapObjects
+	metrics["HeapReleased"] = memStats.HeapReleased
+	metrics["HeapSys"] = memStats.HeapSys
+	metrics["LastGC"] = memStats.LastGC
+	metrics["Lookups"] = memStats.Lookups
+	metrics["MCacheInuse"] = memStats.MCacheInuse
+	metrics["MCacheSys"] = memStats.MCacheSys
+	metrics["MSpanInuse"] = memStats.MSpanInuse
+	metrics["MSpanSys"] = memStats.MSpanSys
+	metrics["Mallocs"] = memStats.Mallocs
+	metrics["NextGC"] = memStats.NextGC
+	metrics["NumForcedGC"] = memStats.NumForcedGC
+	metrics["NumGC"] = memStats.NumGC
+	metrics["OtherSys"] = memStats.OtherSys
+	metrics["PauseTotalNs"] = memStats.PauseTotalNs
+	metrics["StackInuse"] = memStats.StackInuse
+	metrics["StackSys"] = memStats.StackSys
+	metrics["Sys"] = memStats.Sys
+	metrics["TotalAlloc"] = memStats.TotalAlloc
+
+	pollCont++
+	metrics["PollCount"] = pollCont
+
+	metrics["RandomValue"] = rand.Float64()
+
+	return metrics
+
+}
+
+func sendMetric(metricType string, metricName string, metricValue interface{}) error {
+	url := fmt.Sprintf("http://localhost:8080/update/%s/%s/%v", metricType, metricName, metricValue)
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		fmt.Println("Error creating request:", err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", "text/plain")
+
+	client := &http.Client{}
+	_, err = client.Do(req)
+
+	// resp, err := client.Do(req)
+	// // ===============
+	// fmt.Printf("Status: %s\r\n", resp.Status)
+	// fmt.Printf("Header ===============\r\n")
+	// for k, v := range resp.Header {
+	// 	fmt.Printf("%s: %v\r\n", k, v)
+	// }
+	// fmt.Printf("ContentLength: %v\n", resp.ContentLength)
+	// fmt.Printf("Body: %v\n", resp.Body)
+	// fmt.Printf("Query parameters ===============\r\n")
+
+	// // ===============
+
+	if err != nil {
+		fmt.Println("Error sending metric:", err)
+		return err
+	}
+	fmt.Printf("Sent metric: %s/%s/%v\n", metricType, metricName, metricValue)
+	return err
+}
+
+func main() {
+
+	n := int64(0)
+
+	for {
+		time.Sleep(time.Duration(pollInterval) * time.Second)
+		n += pollInterval
+
+		metrics := collectMetrics()
+
+		if reportInterval == n {
+			n = 0
+
+			for metricName, metricValue := range metrics {
+				var metricType string
+				if metricName == "PollCount" {
+					metricType = "counter"
+				} else {
+					metricType = "gauge"
+				}
+				err := sendMetric(metricType, metricName, metricValue)
+				if err != nil {
+					fmt.Printf("Ошибка при отправке метрики %s: %s\n", metricName, err)
+				} else {
+					// fmt.Printf("Метрика %s успешно отправлена \n", metricName)
+				}
+			}
+		}
+	}
+}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -69,13 +69,13 @@ func sendMetric(metricType string, metricName string, metricValue interface{}) e
 	req.Header.Set("Content-Type", "text/plain")
 
 	client := &http.Client{}
-	_, err = client.Do(req)
-	defer req.Body.Close()
+	resp, err := client.Do(req)
 
 	if err != nil {
 		fmt.Println("Error sending metric:", err)
 		return err
 	}
+	defer resp.Body.Close()
 	fmt.Printf("Sent metric: %s/%s/%v\n", metricType, metricName, metricValue)
 	return err
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -71,19 +71,6 @@ func sendMetric(metricType string, metricName string, metricValue interface{}) e
 	client := &http.Client{}
 	_, err = client.Do(req)
 
-	// resp, err := client.Do(req)
-	// // ===============
-	// fmt.Printf("Status: %s\r\n", resp.Status)
-	// fmt.Printf("Header ===============\r\n")
-	// for k, v := range resp.Header {
-	// 	fmt.Printf("%s: %v\r\n", k, v)
-	// }
-	// fmt.Printf("ContentLength: %v\n", resp.ContentLength)
-	// fmt.Printf("Body: %v\n", resp.Body)
-	// fmt.Printf("Query parameters ===============\r\n")
-
-	// // ===============
-
 	if err != nil {
 		fmt.Println("Error sending metric:", err)
 		return err

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -103,7 +103,7 @@ func main() {
 				err := sendMetric(metricType, metricName, metricValue)
 				if err != nil {
 					fmt.Printf("Ошибка при отправке метрики %s: %s\n", metricName, err)
-				} else {
+					// } else {
 					// fmt.Printf("Метрика %s успешно отправлена \n", metricName)
 				}
 			}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -70,6 +70,7 @@ func sendMetric(metricType string, metricName string, metricValue interface{}) e
 
 	client := &http.Client{}
 	_, err = client.Do(req)
+	defer req.Body.Close()
 
 	if err != nil {
 		fmt.Println("Error sending metric:", err)

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,111 +3,16 @@ package main
 import (
 	"net/http"
 
-	. "github.com/maryakotova/metrics/internal/handlers"
-	. "github.com/maryakotova/metrics/internal/storage"
+	"github.com/maryakotova/metrics/internal/handlers"
+	"github.com/maryakotova/metrics/internal/storage"
 
 	"github.com/go-chi/chi/v5"
 )
 
-// type MemStorage struct {
-// 	gauge   map[string]float64
-// 	counter map[string]int64
-// }
-
-// func NewMemStorage() *MemStorage {
-// 	return &MemStorage{
-// 		gauge:   make(map[string]float64),
-// 		counter: make(map[string]int64),
-// 	}
-// }
-
-// func (ms *MemStorage) SetGauge(key string, value float64) {
-// 	ms.gauge[key] = value
-// }
-
-// func (ms *MemStorage) StrValueToFloat(str string) (value float64, err error) {
-// 	value, err = strconv.ParseFloat(str, 64)
-// 	return
-// }
-
-// func (ms *MemStorage) StrValueToInt(str string) (value int64, err error) {
-// 	value, err = strconv.ParseInt(str, 10, 64)
-// 	return
-// }
-
-// func (ms *MemStorage) SetCounter(key string, value int64) {
-// 	_, ok := ms.counter[key]
-// 	if ok {
-// 		ms.counter[key] += value
-
-// 	} else {
-// 		ms.counter[key] = value
-// 	}
-// }
-
-// func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Request) {
-// 	if req.Method != http.MethodPost {
-// 		// http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusMethodNotAllowed)
-// 		res.WriteHeader(http.StatusMethodNotAllowed)
-// 		return
-// 	}
-
-// 	res.Header().Set("Content-Type", "text/plain")
-
-// 	parcedURL := strings.Split(req.URL.Path, "/")
-// 	if len(parcedURL) < 5 {
-// 		http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusNotFound)
-// 		return
-// 	} else if parcedURL[1] != "update" {
-// 		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedURL[2], http.StatusNotFound)
-// 		return
-// 	} else if len(parcedURL) == 6 && parcedURL[6] != "" || len(parcedURL) > 6 {
-// 		http.Error(res, "Невозможно обновить метрику(слишком много параметров)", http.StatusNotFound)
-// 	}
-
-// 	metricType := parcedURL[2]
-// 	metricName := parcedURL[3]
-// 	metricValue := parcedURL[4]
-
-// 	if metricName == "" || metricValue == "" {
-// 		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
-// 		return
-// 	}
-
-// 	switch metricType {
-// 	case "gauge":
-// 		gaugeValue, err := ms.StrValueToFloat(metricValue)
-// 		if err != nil {
-// 			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
-// 			return
-// 		}
-// 		ms.SetGauge(metricName, gaugeValue)
-
-// 	case "counter":
-// 		counterValue, err := ms.StrValueToInt(metricValue)
-// 		if err != nil {
-// 			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
-// 			return
-// 		}
-// 		ms.SetCounter(metricName, counterValue)
-
-// 	default:
-// 		http.Error(res, "Неверный формат для обновления метрик (неверное имя)", http.StatusBadRequest)
-// 		return
-// 	}
-
-// 	res.WriteHeader(http.StatusOK)
-
-// }
-
-// func handleBasic(res http.ResponseWriter, req *http.Request) {
-// 	http.Error(res, "Неверная ссылка для обновления метрики", http.StatusNotFound)
-// }
-
 func main() {
 
-	memStorage := NewMemStorage()
-	server := NewServer(memStorage)
+	memStorage := storage.NewMemStorage()
+	server := handlers.NewServer(memStorage)
 
 	router := chi.NewRouter()
 	router.Use()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/http"
-	"strings"
 
 	. "github.com/maryakotova/metrics/internal/handlers"
 	. "github.com/maryakotova/metrics/internal/storage"
@@ -44,60 +43,60 @@ import (
 // 	}
 // }
 
-func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Request) {
-	if req.Method != http.MethodPost {
-		// http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusMethodNotAllowed)
-		res.WriteHeader(http.StatusMethodNotAllowed)
-		return
-	}
+// func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Request) {
+// 	if req.Method != http.MethodPost {
+// 		// http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusMethodNotAllowed)
+// 		res.WriteHeader(http.StatusMethodNotAllowed)
+// 		return
+// 	}
 
-	res.Header().Set("Content-Type", "text/plain")
+// 	res.Header().Set("Content-Type", "text/plain")
 
-	parcedURL := strings.Split(req.URL.Path, "/")
-	if len(parcedURL) < 5 {
-		http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusNotFound)
-		return
-	} else if parcedURL[1] != "update" {
-		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedURL[2], http.StatusNotFound)
-		return
-	} else if len(parcedURL) == 6 && parcedURL[6] != "" || len(parcedURL) > 6 {
-		http.Error(res, "Невозможно обновить метрику(слишком много параметров)", http.StatusNotFound)
-	}
+// 	parcedURL := strings.Split(req.URL.Path, "/")
+// 	if len(parcedURL) < 5 {
+// 		http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusNotFound)
+// 		return
+// 	} else if parcedURL[1] != "update" {
+// 		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedURL[2], http.StatusNotFound)
+// 		return
+// 	} else if len(parcedURL) == 6 && parcedURL[6] != "" || len(parcedURL) > 6 {
+// 		http.Error(res, "Невозможно обновить метрику(слишком много параметров)", http.StatusNotFound)
+// 	}
 
-	metricType := parcedURL[2]
-	metricName := parcedURL[3]
-	metricValue := parcedURL[4]
+// 	metricType := parcedURL[2]
+// 	metricName := parcedURL[3]
+// 	metricValue := parcedURL[4]
 
-	if metricName == "" || metricValue == "" {
-		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
-		return
-	}
+// 	if metricName == "" || metricValue == "" {
+// 		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
+// 		return
+// 	}
 
-	switch metricType {
-	case "gauge":
-		gaugeValue, err := ms.StrValueToFloat(metricValue)
-		if err != nil {
-			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
-			return
-		}
-		ms.SetGauge(metricName, gaugeValue)
+// 	switch metricType {
+// 	case "gauge":
+// 		gaugeValue, err := ms.StrValueToFloat(metricValue)
+// 		if err != nil {
+// 			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
+// 			return
+// 		}
+// 		ms.SetGauge(metricName, gaugeValue)
 
-	case "counter":
-		counterValue, err := ms.StrValueToInt(metricValue)
-		if err != nil {
-			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
-			return
-		}
-		ms.SetCounter(metricName, counterValue)
+// 	case "counter":
+// 		counterValue, err := ms.StrValueToInt(metricValue)
+// 		if err != nil {
+// 			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
+// 			return
+// 		}
+// 		ms.SetCounter(metricName, counterValue)
 
-	default:
-		http.Error(res, "Неверный формат для обновления метрик (неверное имя)", http.StatusBadRequest)
-		return
-	}
+// 	default:
+// 		http.Error(res, "Неверный формат для обновления метрик (неверное имя)", http.StatusBadRequest)
+// 		return
+// 	}
 
-	res.WriteHeader(http.StatusOK)
+// 	res.WriteHeader(http.StatusOK)
 
-}
+// }
 
 // func handleBasic(res http.ResponseWriter, req *http.Request) {
 // 	http.Error(res, "Неверная ссылка для обновления метрики", http.StatusNotFound)
@@ -106,9 +105,10 @@ func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Requ
 func main() {
 
 	memStorage := NewMemStorage()
+	server := NewServer(memStorage)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc(`/update/`, memStorage.handleMetricUpdate)
+	mux.HandleFunc(`/update/`, server.HandleMetricUpdate)
 	// mux.HandleFunc(`//`, memStorage.handleMetricUpdate)
 	// mux.HandleFunc(`/`, handleBasic)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,20 +51,20 @@ func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Requ
 
 	res.Header().Set("Content-Type", "text/plain")
 
-	parcedUrl := strings.Split(req.URL.Path, "/")
-	if len(parcedUrl) < 5 {
+	parcedURL := strings.Split(req.URL.Path, "/")
+	if len(parcedURL) < 5 {
 		http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusNotFound)
 		return
-	} else if parcedUrl[1] != "update" {
-		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedUrl[2], http.StatusNotFound)
+	} else if parcedURL[1] != "update" {
+		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedURL[2], http.StatusNotFound)
 		return
-	} else if len(parcedUrl) == 6 && parcedUrl[6] != "" || len(parcedUrl) > 6 {
+	} else if len(parcedURL) == 6 && parcedURL[6] != "" || len(parcedURL) > 6 {
 		http.Error(res, "Невозможно обновить метрику(слишком много параметров)", http.StatusNotFound)
 	}
 
-	metricType := parcedUrl[2]
-	metricName := parcedUrl[3]
-	metricValue := parcedUrl[4]
+	metricType := parcedURL[2]
+	metricName := parcedURL[3]
+	metricValue := parcedURL[4]
 
 	if metricName == "" || metricValue == "" {
 		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"net/http"
 
 	"github.com/maryakotova/metrics/internal/handlers"
@@ -10,6 +12,9 @@ import (
 )
 
 func main() {
+
+	netAddress := flag.String("a", "localhost:8080", "Адрес и порт для HTTP-сервера")
+	flag.Parse()
 
 	memStorage := storage.NewMemStorage()
 	server := handlers.NewServer(memStorage)
@@ -21,9 +26,11 @@ func main() {
 	router.Get("/value/{metricType}/{metricName}", server.HandleGetOneMetric)
 	router.Post("/update/{metricType}/{metricName}/{metricValue}", server.HandleMetricUpdate)
 
-	err := http.ListenAndServe(":8080", router)
+	err := http.ListenAndServe(*netAddress, router)
 	if err != nil {
 		panic(err)
 	}
+
+	fmt.Println("Running server on ", netAddress)
 
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,8 @@ import (
 
 	. "github.com/maryakotova/metrics/internal/handlers"
 	. "github.com/maryakotova/metrics/internal/storage"
+
+	"github.com/go-chi/chi/v5"
 )
 
 // type MemStorage struct {
@@ -107,13 +109,16 @@ func main() {
 	memStorage := NewMemStorage()
 	server := NewServer(memStorage)
 
-	mux := http.NewServeMux()
-	mux.HandleFunc(`/update/`, server.HandleMetricUpdate)
-	// mux.HandleFunc(`//`, memStorage.handleMetricUpdate)
-	// mux.HandleFunc(`/`, handleBasic)
+	router := chi.NewRouter()
+	router.Use()
 
-	err := http.ListenAndServe(`:8080`, mux)
+	router.Get("/", server.HandleGetAllMetrics)
+	router.Get("/value/{metricType}/{metricName}", server.HandleGetOneMetric)
+	router.Post("/update/{metricType}/{metricName}/{metricValue}", server.HandleMetricUpdate)
+
+	err := http.ListenAndServe(":8080", router)
 	if err != nil {
 		panic(err)
 	}
+
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,117 @@
 package main
 
-func main() {}
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type MemStorage struct {
+	gauge   map[string]float64
+	counter map[string]int64
+}
+
+func NewMemStorage() *MemStorage {
+	return &MemStorage{
+		gauge:   make(map[string]float64),
+		counter: make(map[string]int64),
+	}
+}
+
+func (ms *MemStorage) SetGauge(key string, value float64) {
+	ms.gauge[key] = value
+}
+
+func (ms *MemStorage) StrValueToFloat(str string) (value float64, err error) {
+	value, err = strconv.ParseFloat(str, 64)
+	return
+}
+
+func (ms *MemStorage) StrValueToInt(str string) (value int64, err error) {
+	value, err = strconv.ParseInt(str, 10, 64)
+	return
+}
+
+func (ms *MemStorage) SetCounter(key string, value int64) {
+	_, ok := ms.counter[key]
+	if ok {
+		ms.counter[key] += value
+
+	} else {
+		ms.counter[key] = value
+	}
+}
+
+func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		// http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusMethodNotAllowed)
+		res.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	res.Header().Set("Content-Type", "text/plain")
+
+	parcedUrl := strings.Split(req.URL.Path, "/")
+	if len(parcedUrl) < 5 {
+		http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusNotFound)
+		return
+	} else if parcedUrl[1] != "update" {
+		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedUrl[2], http.StatusNotFound)
+		return
+	} else if len(parcedUrl) == 6 && parcedUrl[6] != "" || len(parcedUrl) > 6 {
+		http.Error(res, "Невозможно обновить метрику(слишком много параметров)", http.StatusNotFound)
+	}
+
+	metricType := parcedUrl[2]
+	metricName := parcedUrl[3]
+	metricValue := parcedUrl[4]
+
+	if metricName == "" || metricValue == "" {
+		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
+		return
+	}
+
+	switch metricType {
+	case "gauge":
+		gaugeValue, err := ms.StrValueToFloat(metricValue)
+		if err != nil {
+			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
+			return
+		}
+		ms.SetGauge(metricName, gaugeValue)
+
+	case "counter":
+		counterValue, err := ms.StrValueToInt(metricValue)
+		if err != nil {
+			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
+			return
+		}
+		ms.SetCounter(metricName, counterValue)
+
+	default:
+		http.Error(res, "Неверный формат для обновления метрик (неверное имя)", http.StatusBadRequest)
+		return
+	}
+
+	res.WriteHeader(http.StatusOK)
+
+}
+
+func handleBasic(res http.ResponseWriter, req *http.Request) {
+	http.Error(res, "Неверная ссылка для обновления метрики", http.StatusNotFound)
+}
+
+func main() {
+
+	memStorage := NewMemStorage()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(`/update/`, memStorage.handleMetricUpdate)
+	mux.HandleFunc(`//`, memStorage.handleMetricUpdate)
+	mux.HandleFunc(`/`, handleBasic)
+
+	err := http.ListenAndServe(`:8080`, mux)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/maryakotova/metrics
 
 go 1.22.10
+
+require github.com/go-chi/chi/v5 v5.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/maryakotova/metrics
+
+go 1.23.3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/maryakotova/metrics
 
-go 1.23.3
+go 1.22.10

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.0 h1:Aj1EtB0qR2Rdo2dG4O94RIU35w2lvQSj6BRA4+qwFL0=
+github.com/go-chi/chi/v5 v5.2.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,48 +1,9 @@
-package main
+package handlers
 
 import (
 	"net/http"
 	"strings"
-
-	. "github.com/maryakotova/metrics/internal/handlers"
-	. "github.com/maryakotova/metrics/internal/storage"
 )
-
-// type MemStorage struct {
-// 	gauge   map[string]float64
-// 	counter map[string]int64
-// }
-
-// func NewMemStorage() *MemStorage {
-// 	return &MemStorage{
-// 		gauge:   make(map[string]float64),
-// 		counter: make(map[string]int64),
-// 	}
-// }
-
-// func (ms *MemStorage) SetGauge(key string, value float64) {
-// 	ms.gauge[key] = value
-// }
-
-// func (ms *MemStorage) StrValueToFloat(str string) (value float64, err error) {
-// 	value, err = strconv.ParseFloat(str, 64)
-// 	return
-// }
-
-// func (ms *MemStorage) StrValueToInt(str string) (value int64, err error) {
-// 	value, err = strconv.ParseInt(str, 10, 64)
-// 	return
-// }
-
-// func (ms *MemStorage) SetCounter(key string, value int64) {
-// 	_, ok := ms.counter[key]
-// 	if ok {
-// 		ms.counter[key] += value
-
-// 	} else {
-// 		ms.counter[key] = value
-// 	}
-// }
 
 func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
@@ -97,23 +58,4 @@ func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Requ
 
 	res.WriteHeader(http.StatusOK)
 
-}
-
-// func handleBasic(res http.ResponseWriter, req *http.Request) {
-// 	http.Error(res, "Неверная ссылка для обновления метрики", http.StatusNotFound)
-// }
-
-func main() {
-
-	memStorage := NewMemStorage()
-
-	mux := http.NewServeMux()
-	mux.HandleFunc(`/update/`, memStorage.handleMetricUpdate)
-	// mux.HandleFunc(`//`, memStorage.handleMetricUpdate)
-	// mux.HandleFunc(`/`, handleBasic)
-
-	err := http.ListenAndServe(`:8080`, mux)
-	if err != nil {
-		panic(err)
-	}
 }

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,71 +1,107 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
-
-	. "github.com/maryakotova/metrics/internal/storage"
 )
 
-type Server struct {
-	metrics MemStorage
+type DataStorage interface {
+	SetGauge(key string, value string) (err error)
+	SetCounter(key string, value string) (err error)
+	GetAll() map[string]interface{}
+	GetGauge(key string) (value float64, err error)
+	GetCounter(key string) (value int64, err error)
 }
 
-func NewServer(metrics *MemStorage) *Server {
-	return &Server{metrics: *metrics}
+type Server struct {
+	metrics DataStorage
+}
+
+func NewServer(metrics DataStorage) *Server {
+	return &Server{metrics: metrics}
 }
 
 func (server *Server) HandleMetricUpdate(res http.ResponseWriter, req *http.Request) {
-	if req.Method != http.MethodPost {
-		// http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusMethodNotAllowed)
-		res.WriteHeader(http.StatusMethodNotAllowed)
-		return
-	}
-
 	res.Header().Set("Content-Type", "text/plain")
 
-	parcedURL := strings.Split(req.URL.Path, "/")
-	if len(parcedURL) < 5 {
-		http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusNotFound)
-		return
-	} else if parcedURL[1] != "update" {
-		http.Error(res, "Невозможно обновить метрику(где update?) "+parcedURL[2], http.StatusNotFound)
-		return
-	} else if len(parcedURL) == 6 && parcedURL[6] != "" || len(parcedURL) > 6 {
-		http.Error(res, "Невозможно обновить метрику(слишком много параметров)", http.StatusNotFound)
-	}
+	metricType := req.PathValue("metricType")
+	metricName := req.PathValue("metricName")
+	metricValue := req.PathValue("metricValue")
 
-	metricType := parcedURL[2]
-	metricName := parcedURL[3]
-	metricValue := parcedURL[4]
-
-	if metricName == "" || metricValue == "" {
+	if metricName == "" {
 		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
 		return
 	}
 
 	switch metricType {
 	case "gauge":
-		gaugeValue, err := server.metrics.StrValueToFloat(metricValue)
+		err := server.metrics.SetGauge(metricName, metricValue)
 		if err != nil {
 			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
 			return
 		}
-		server.metrics.SetGauge(metricName, gaugeValue)
 
 	case "counter":
-		counterValue, err := server.metrics.StrValueToInt(metricValue)
+		err := server.metrics.SetCounter(metricName, metricValue)
 		if err != nil {
 			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
 			return
 		}
-		server.metrics.SetCounter(metricName, counterValue)
 
 	default:
-		http.Error(res, "Неверный формат для обновления метрик (неверное имя)", http.StatusBadRequest)
+		http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
 		return
 	}
 
 	res.WriteHeader(http.StatusOK)
+}
 
+func (server *Server) HandleGetOneMetric(res http.ResponseWriter, req *http.Request) {
+
+	res.Header().Set("Content-Type", "text/plain")
+
+	// switch chi.URLParam(req, "type") { !!!Почему не работает??????
+	switch req.PathValue("metricType") {
+	case "gauge":
+		metricValue, err := server.metrics.GetGauge(req.PathValue("metricName"))
+		if err != nil {
+			http.Error(res, "Запрос неизвестной метрики", http.StatusNotFound)
+			return
+		}
+		res.WriteHeader(http.StatusOK)
+		res.Write([]byte(strconv.FormatFloat(metricValue, 'f', -1, 64)))
+
+	case "counter":
+		metricValue, err := server.metrics.GetCounter(req.PathValue("metricName"))
+		if err != nil {
+			http.Error(res, "Запрос неизвестной метрики", http.StatusNotFound)
+			return
+		}
+		res.WriteHeader(http.StatusOK)
+		res.Write([]byte(strconv.FormatInt(metricValue, 10)))
+
+	case "":
+		http.Error(res, "Тип метрики обязателен для заполнения", http.StatusBadRequest)
+		return
+
+	default:
+		http.Error(res, "Указанный тип метрики не известен", http.StatusNotFound)
+		return
+	}
+}
+
+func (server *Server) HandleGetAllMetrics(res http.ResponseWriter, req *http.Request) {
+
+	res.Header().Set("Content-Type", "text/plain")
+
+	metricsList := server.metrics.GetAll()
+
+	var sb strings.Builder
+	for key, value := range metricsList {
+		sb.WriteString(fmt.Sprintf("%s: %v\n", key, value))
+	}
+
+	res.Write([]byte(sb.String()))
 }

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -3,9 +3,19 @@ package handlers
 import (
 	"net/http"
 	"strings"
+
+	. "github.com/maryakotova/metrics/internal/storage"
 )
 
-func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Request) {
+type Server struct {
+	metrics MemStorage
+}
+
+func NewServer(metrics *MemStorage) *Server {
+	return &Server{metrics: *metrics}
+}
+
+func (server *Server) HandleMetricUpdate(res http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		// http.Error(res, "Невозможно обновить метрику(недостаточно параметров)", http.StatusMethodNotAllowed)
 		res.WriteHeader(http.StatusMethodNotAllowed)
@@ -36,20 +46,20 @@ func (ms *MemStorage) handleMetricUpdate(res http.ResponseWriter, req *http.Requ
 
 	switch metricType {
 	case "gauge":
-		gaugeValue, err := ms.StrValueToFloat(metricValue)
+		gaugeValue, err := server.metrics.StrValueToFloat(metricValue)
 		if err != nil {
 			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
 			return
 		}
-		ms.SetGauge(metricName, gaugeValue)
+		server.metrics.SetGauge(metricName, gaugeValue)
 
 	case "counter":
-		counterValue, err := ms.StrValueToInt(metricValue)
+		counterValue, err := server.metrics.StrValueToInt(metricValue)
 		if err != nil {
 			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
 			return
 		}
-		ms.SetCounter(metricName, counterValue)
+		server.metrics.SetCounter(metricName, counterValue)
 
 	default:
 		http.Error(res, "Неверный формат для обновления метрик (неверное имя)", http.StatusBadRequest)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -65,17 +65,17 @@ func (ms *MemStorage) GetCounter(key string) (value int64, err error) {
 }
 
 func (ms *MemStorage) GetAllGauge() map[string]float64 {
-	return ms.gauge[]
-} 
+	return ms.gauge
+}
 
 func (ms *MemStorage) GetAllCounter() map[string]int64 {
-	return ms.counter[]
-} 
-
-func (ms *MemStorage) GetAll() result map[string]interface {
-	result = ms.gauge[]
-	for key, value := range ms.counter {
-		result[key] = value
-	}
-	return
+	return ms.counter
 }
+
+// func (ms *MemStorage) GetAll() result map[string]interface{} {
+// 	result = ms.gauge
+// 	for key, value := range ms.counter {
+// 		result[key] = value
+// 	}
+// 	return
+// }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,81 @@
+package storage
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type MetricType string
+
+const (
+	Gauge   MetricType = "gauge"
+	Counter MetricType = "counter"
+)
+
+type MemStorage struct {
+	gauge   map[string]float64
+	counter map[string]int64
+}
+
+func NewMemStorage() *MemStorage {
+	return &MemStorage{
+		gauge:   make(map[string]float64),
+		counter: make(map[string]int64),
+	}
+}
+
+func (ms *MemStorage) SetGauge(key string, value float64) {
+	ms.gauge[key] = value
+}
+
+func (ms *MemStorage) StrValueToFloat(str string) (value float64, err error) {
+	value, err = strconv.ParseFloat(str, 64)
+	return
+}
+
+func (ms *MemStorage) StrValueToInt(str string) (value int64, err error) {
+	value, err = strconv.ParseInt(str, 10, 64)
+	return
+}
+
+func (ms *MemStorage) SetCounter(key string, value int64) {
+	_, ok := ms.counter[key]
+	if ok {
+		ms.counter[key] += value
+
+	} else {
+		ms.counter[key] = value
+	}
+}
+
+func (ms *MemStorage) GetGauge(key string) (value float64, err error) {
+	value, ok := ms.gauge[key]
+	if ok != true {
+		err = fmt.Errorf("Значение метрики %s типа gauge не найдено", key)
+	}
+	return
+}
+
+func (ms *MemStorage) GetCounter(key string) (value int64, err error) {
+	value, ok := ms.counter[key]
+	if ok != true {
+		err = fmt.Errorf("Значение метрики %s типа Counter не найдено", key)
+	}
+	return
+}
+
+func (ms *MemStorage) GetAllGauge() map[string]float64 {
+	return ms.gauge[]
+} 
+
+func (ms *MemStorage) GetAllCounter() map[string]int64 {
+	return ms.counter[]
+} 
+
+func (ms *MemStorage) GetAll() result map[string]interface {
+	result = ms.gauge[]
+	for key, value := range ms.counter {
+		result[key] = value
+	}
+	return
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -69,6 +69,7 @@ func (ms *MemStorage) SetCounter(key string, value string) (err error) {
 }
 
 func (ms *MemStorage) GetGauge(key string) (value float64, err error) {
+
 	value, ok := ms.gauge[key]
 	if !ok {
 		err = fmt.Errorf("значение метрики %s типа gauge не найдено", key)
@@ -84,13 +85,13 @@ func (ms *MemStorage) GetCounter(key string) (value int64, err error) {
 	return
 }
 
-// func (ms *MemStorage) GetAllGauge() map[string]float64 {
-// 	return ms.gauge
-// }
+func (ms *MemStorage) GetAllGauge() map[string]float64 {
+	return ms.gauge
+}
 
-// func (ms *MemStorage) GetAllCounter() map[string]int64 {
-// 	return ms.counter
-// }
+func (ms *MemStorage) GetAllCounter() map[string]int64 {
+	return ms.counter
+}
 
 func (ms *MemStorage) GetAll() map[string]interface{} {
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,15 +1,15 @@
 package storage
 
+// type MetricType string
+
 import (
 	"fmt"
 	"strconv"
 )
 
-type MetricType string
-
 const (
-	Gauge   MetricType = "gauge"
-	Counter MetricType = "counter"
+	Gauge   string = "gauge"
+	Counter string = "counter"
 )
 
 type MemStorage struct {
@@ -24,58 +24,85 @@ func NewMemStorage() *MemStorage {
 	}
 }
 
-func (ms *MemStorage) SetGauge(key string, value float64) {
-	ms.gauge[key] = value
-}
-
-func (ms *MemStorage) StrValueToFloat(str string) (value float64, err error) {
+func (ms *MemStorage) strValueToFloat(str string) (value float64, err error) {
 	value, err = strconv.ParseFloat(str, 64)
 	return
 }
 
-func (ms *MemStorage) StrValueToInt(str string) (value int64, err error) {
+func (ms *MemStorage) SetGauge(key string, value string) (err error) {
+	if key == "" {
+		err = fmt.Errorf("имя метрики обязательно для заполнения")
+		return
+	}
+	floatValue, err := ms.strValueToFloat(value)
+	if err != nil {
+		return err
+	}
+
+	ms.gauge[key] = floatValue
+	return
+}
+
+func (ms *MemStorage) strValueToInt(str string) (value int64, err error) {
 	value, err = strconv.ParseInt(str, 10, 64)
 	return
 }
 
-func (ms *MemStorage) SetCounter(key string, value int64) {
+func (ms *MemStorage) SetCounter(key string, value string) (err error) {
+	if key == "" {
+		err = fmt.Errorf("имя метрики обязательно для заполнения")
+		return
+	}
+	intValue, err := ms.strValueToInt(value)
+	if err != nil {
+		return err
+	}
+
 	_, ok := ms.counter[key]
 	if ok {
-		ms.counter[key] += value
+		ms.counter[key] += intValue
 
 	} else {
-		ms.counter[key] = value
+		ms.counter[key] = intValue
 	}
+	return
 }
 
 func (ms *MemStorage) GetGauge(key string) (value float64, err error) {
 	value, ok := ms.gauge[key]
-	if ok != true {
-		err = fmt.Errorf("Значение метрики %s типа gauge не найдено", key)
+	if !ok {
+		err = fmt.Errorf("значение метрики %s типа gauge не найдено", key)
 	}
 	return
 }
 
 func (ms *MemStorage) GetCounter(key string) (value int64, err error) {
 	value, ok := ms.counter[key]
-	if ok != true {
-		err = fmt.Errorf("Значение метрики %s типа Counter не найдено", key)
+	if !ok {
+		err = fmt.Errorf("значение метрики %s типа Counter не найдено", key)
 	}
 	return
 }
 
-func (ms *MemStorage) GetAllGauge() map[string]float64 {
-	return ms.gauge
-}
-
-func (ms *MemStorage) GetAllCounter() map[string]int64 {
-	return ms.counter
-}
-
-// func (ms *MemStorage) GetAll() result map[string]interface{} {
-// 	result = ms.gauge
-// 	for key, value := range ms.counter {
-// 		result[key] = value
-// 	}
-// 	return
+// func (ms *MemStorage) GetAllGauge() map[string]float64 {
+// 	return ms.gauge
 // }
+
+// func (ms *MemStorage) GetAllCounter() map[string]int64 {
+// 	return ms.counter
+// }
+
+func (ms *MemStorage) GetAll() map[string]interface{} {
+
+	allMetrics := make(map[string]interface{})
+
+	for key, value := range ms.gauge {
+		allMetrics[key] = value
+	}
+
+	for key, value := range ms.counter {
+		allMetrics[key] = value
+	}
+
+	return allMetrics
+}


### PR DESCRIPTION
Сервис принимает аргументы с использованием флагов.
Аргументы сервера:
Флаг -a=<ЗНАЧЕНИЕ> отвечает за адрес эндпоинта HTTP-сервера (по умолчанию localhost:8080).
Аргументы агента:
Флаг -a=<ЗНАЧЕНИЕ> отвечает за адрес эндпоинта HTTP-сервера (по умолчанию localhost:8080).
Флаг -r=<ЗНАЧЕНИЕ> позволяет переопределять reportInterval — частоту отправки метрик на сервер (по умолчанию 10 секунд).
Флаг -p=<ЗНАЧЕНИЕ> позволяет переопределять pollInterval — частоту опроса метрик из пакета runtime (по умолчанию 2 секунды).