### PR TITLE
Iter7

### DIFF
--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,1 +1,18 @@
 package main
+
+// import "testing"
+
+// func Test_main(t *testing.T) {
+// 	tests := []struct {
+// 		name string
+// 		metrics map[string]interface{}
+
+// 	}{
+// 		// TODO: Add test cases.
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			main()
+// 		})
+// 	}
+// }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,8 +25,10 @@ func main() {
 	router.Use()
 
 	router.Get("/", logger.WithLogging(server.HandleGetAllMetrics))
-	router.Post("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
+	router.Get("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
+	router.Post("/value/", logger.WithLogging(server.HandleGetOneMetricViaJSON))
 	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
+	router.Post("/update/", logger.WithLogging(server.HandleMetricUpdateViaJSON))
 
 	err := http.ListenAndServe(netAddress, router)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,7 +32,7 @@ func main() {
 	router.Post("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetricViaJSON))
 
 	// router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
-	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdateViaJSON))
+	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
 	router.Post("/update/", logger.WithLogging(server.HandleMetricUpdateViaJSON))
 
 	err := http.ListenAndServe(netAddress, router)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,9 +26,9 @@ func main() {
 
 	router.Get("/", logger.WithLogging(server.HandleGetAllMetrics))
 	router.Get("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
-	router.Post("/value/", logger.WithLogging(server.HandleGetOneMetricViaJSON))
+	router.Post("/value", logger.WithLogging(server.HandleGetOneMetricViaJSON))
 	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
-	router.Post("/update/", logger.WithLogging(server.HandleMetricUpdateViaJSON))
+	router.Post("/update", logger.WithLogging(server.HandleMetricUpdateViaJSON))
 
 	err := http.ListenAndServe(netAddress, router)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/maryakotova/metrics/internal/handlers"
+	"github.com/maryakotova/metrics/internal/logger"
 	"github.com/maryakotova/metrics/internal/storage"
 
 	"github.com/go-chi/chi/v5"
@@ -13,15 +14,19 @@ func main() {
 
 	parseFlags()
 
+	if err := logger.Initialize(""); err != nil {
+		panic(err)
+	}
+
 	memStorage := storage.NewMemStorage()
 	server := handlers.NewServer(memStorage)
 
 	router := chi.NewRouter()
 	router.Use()
 
-	router.Get("/", server.HandleGetAllMetrics)
-	router.Get("/value/{metricType}/{metricName}", server.HandleGetOneMetric)
-	router.Post("/update/{metricType}/{metricName}/{metricValue}", server.HandleMetricUpdate)
+	router.Get("/", logger.WithLogging(server.HandleGetAllMetrics))
+	router.Get("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
+	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
 
 	err := http.ListenAndServe(netAddress, router)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,8 +25,8 @@ func main() {
 	router.Use()
 
 	router.Get("/", logger.WithLogging(server.HandleGetAllMetrics))
-	router.Post("/value/", logger.WithLogging(server.HandleGetOneMetric))
-	router.Post("/update/", logger.WithLogging(server.HandleMetricUpdate))
+	router.Post("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
+	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
 
 	err := http.ListenAndServe(netAddress, router)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,11 +27,10 @@ func main() {
 	router.Get("/", logger.WithLogging(server.HandleGetAllMetrics))
 	router.Get("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
 
-	router.Post("/value", logger.WithLogging(server.HandleGetOneMetricViaJSON))
+	//router.Post("/value", logger.WithLogging(server.HandleGetOneMetricViaJSON))
 	router.Post("/value/", logger.WithLogging(server.HandleGetOneMetricViaJSON))
-	router.Post("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetricViaJSON))
+	// router.Post("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetricViaJSON))
 
-	// router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
 	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
 	router.Post("/update/", logger.WithLogging(server.HandleMetricUpdateViaJSON))
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,9 +26,14 @@ func main() {
 
 	router.Get("/", logger.WithLogging(server.HandleGetAllMetrics))
 	router.Get("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
+
 	router.Post("/value", logger.WithLogging(server.HandleGetOneMetricViaJSON))
-	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
-	router.Post("/update", logger.WithLogging(server.HandleMetricUpdateViaJSON))
+	router.Post("/value/", logger.WithLogging(server.HandleGetOneMetricViaJSON))
+	router.Post("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetricViaJSON))
+
+	// router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
+	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdateViaJSON))
+	router.Post("/update/", logger.WithLogging(server.HandleMetricUpdateViaJSON))
 
 	err := http.ListenAndServe(netAddress, router)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,8 +25,8 @@ func main() {
 	router.Use()
 
 	router.Get("/", logger.WithLogging(server.HandleGetAllMetrics))
-	router.Get("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
-	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
+	router.Post("/value/", logger.WithLogging(server.HandleGetOneMetric))
+	router.Post("/update/", logger.WithLogging(server.HandleMetricUpdate))
 
 	err := http.ListenAndServe(netAddress, router)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,11 +25,9 @@ func main() {
 	router.Use()
 
 	router.Get("/", logger.WithLogging(server.HandleGetAllMetrics))
-	router.Get("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
 
-	//router.Post("/value", logger.WithLogging(server.HandleGetOneMetricViaJSON))
+	router.Get("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetric))
 	router.Post("/value/", logger.WithLogging(server.HandleGetOneMetricViaJSON))
-	// router.Post("/value/{metricType}/{metricName}", logger.WithLogging(server.HandleGetOneMetricViaJSON))
 
 	router.Post("/update/{metricType}/{metricName}/{metricValue}", logger.WithLogging(server.HandleMetricUpdate))
 	router.Post("/update/", logger.WithLogging(server.HandleMetricUpdateViaJSON))

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,14 @@ require (
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/go-chi/chi/v5 v5.2.0
+	go.uber.org/zap v1.27.0
 )
 
-require github.com/stretchr/testify v1.10.0 // indirect
+require go.uber.org/multierr v1.10.0 // indirect
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,13 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -27,6 +27,11 @@ func NewServer(metrics DataStorage) *Server {
 }
 
 func (server *Server) HandleMetricUpdate(res http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		res.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
 	res.Header().Set("Content-Type", "text/plain")
 
 	metricType := req.PathValue("metricType")
@@ -62,6 +67,10 @@ func (server *Server) HandleMetricUpdate(res http.ResponseWriter, req *http.Requ
 }
 
 func (server *Server) HandleGetOneMetric(res http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		res.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
 
 	res.Header().Set("Content-Type", "text/plain")
 
@@ -96,6 +105,10 @@ func (server *Server) HandleGetOneMetric(res http.ResponseWriter, req *http.Requ
 }
 
 func (server *Server) HandleGetAllMetrics(res http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		res.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
 
 	res.Header().Set("Content-Type", "text/html")
 
@@ -117,4 +130,6 @@ func (server *Server) HandleGetAllMetrics(res http.ResponseWriter, req *http.Req
 	if err != nil {
 		http.Error(res, "Error executing template", http.StatusInternalServerError)
 	}
+
+	res.WriteHeader(http.StatusOK)
 }

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -38,94 +38,94 @@ func (server *Server) HandleMetricUpdateViaJSON(res http.ResponseWriter, req *ht
 	var responce models.Metrics
 
 	contentType := req.Header.Get("Content-Type")
-	switch contentType {
-	case "application/json":
-		var request models.Metrics
-		dec := json.NewDecoder(req.Body)
-		if err := dec.Decode(&request); err != nil {
-			res.WriteHeader(http.StatusInternalServerError)
-			return
-		}
+	// switch contentType {
+	// case "application/json":
+	// 	var request models.Metrics
+	// 	dec := json.NewDecoder(req.Body)
+	// 	if err := dec.Decode(&request); err != nil {
+	// 		res.WriteHeader(http.StatusInternalServerError)
+	// 		return
+	// 	}
 
-		if request.ID == "" {
-			http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
-			return
-		}
+	// 	if request.ID == "" {
+	// 		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
+	// 		return
+	// 	}
 
-		responce.ID = request.ID
-		responce.MType = request.MType
+	// 	responce.ID = request.ID
+	// 	responce.MType = request.MType
 
-		switch request.MType {
-		case "gauge":
-			if err := server.metrics.SetGauge(request.ID, *request.Value); err != nil {
-				http.Error(res, "Ошибка при обновлении метрики Gauge", http.StatusBadRequest)
-				return
-			}
-			responce.Value = request.Value
-		case "counter":
-			if err := server.metrics.SetCounter(request.ID, *request.Delta); err != nil {
-				http.Error(res, "Ошибка при обновлении метрики Counter", http.StatusBadRequest)
-				return
-			}
-			responce.Delta = request.Delta
-		default:
-			http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
-			return
-		}
+	// 	switch request.MType {
+	// 	case "gauge":
+	// 		if err := server.metrics.SetGauge(request.ID, *request.Value); err != nil {
+	// 			http.Error(res, "Ошибка при обновлении метрики Gauge", http.StatusBadRequest)
+	// 			return
+	// 		}
+	// 		responce.Value = request.Value
+	// 	case "counter":
+	// 		if err := server.metrics.SetCounter(request.ID, *request.Delta); err != nil {
+	// 			http.Error(res, "Ошибка при обновлении метрики Counter", http.StatusBadRequest)
+	// 			return
+	// 		}
+	// 		responce.Delta = request.Delta
+	// 	default:
+	// 		http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
+	// 		return
+	// 	}
 
-	case "text/plain", "":
-		metricType := req.PathValue("metricType")
-		metricName := req.PathValue("metricName")
-		metricValue := req.PathValue("metricValue")
+	// case "text/plain", "":
+	metricType := req.PathValue("metricType")
+	metricName := req.PathValue("metricName")
+	metricValue := req.PathValue("metricValue")
 
-		if metricName == "" {
-			http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
-			return
-		}
-
-		// responce := models.Metrics{
-		// 	ID:    metricName,
-		// 	MType: metricType,
-		// }
-
-		responce.ID = metricName
-		responce.MType = metricType
-
-		switch metricType {
-		case "gauge":
-			value, err := strconv.ParseFloat(metricValue, 64)
-			if err != nil {
-				http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
-				return
-			}
-			err = server.metrics.SetGauge(metricName, value)
-			if err != nil {
-				http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
-				return
-			}
-			responce.Value = &value
-
-		case "counter":
-			value, err := strconv.ParseInt(metricValue, 10, 64)
-			if err != nil {
-				http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
-				return
-			}
-			err = server.metrics.SetCounter(metricName, value)
-			if err != nil {
-				http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
-				return
-			}
-			responce.Delta = &value
-
-		default:
-			http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
-			return
-		}
-	default:
-		http.Error(res, "Неверный формат для обновления метрик (Content-Type)", http.StatusBadRequest)
+	if metricName == "" {
+		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
 		return
 	}
+
+	// responce := models.Metrics{
+	// 	ID:    metricName,
+	// 	MType: metricType,
+	// }
+
+	responce.ID = metricName
+	responce.MType = metricType
+
+	switch metricType {
+	case "gauge":
+		value, err := strconv.ParseFloat(metricValue, 64)
+		if err != nil {
+			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
+			return
+		}
+		err = server.metrics.SetGauge(metricName, value)
+		if err != nil {
+			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
+			return
+		}
+		responce.Value = &value
+
+	case "counter":
+		value, err := strconv.ParseInt(metricValue, 10, 64)
+		if err != nil {
+			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
+			return
+		}
+		err = server.metrics.SetCounter(metricName, value)
+		if err != nil {
+			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
+			return
+		}
+		responce.Delta = &value
+
+	default:
+		http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
+		return
+	}
+	// default:
+	// 	http.Error(res, "Неверный формат для обновления метрик (Content-Type)", http.StatusBadRequest)
+	// 	return
+	// }
 
 	res.Header().Set("Content-Type", "Content-Type: application/json")
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -73,7 +73,7 @@ func (server *Server) HandleMetricUpdateViaJSON(res http.ResponseWriter, req *ht
 			return
 		}
 
-	case "text/plain":
+	case "text/plain", "":
 		metricType := req.PathValue("metricType")
 		metricName := req.PathValue("metricName")
 		metricValue := req.PathValue("metricValue")

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -37,7 +37,7 @@ func (server *Server) HandleMetricUpdateViaJSON(res http.ResponseWriter, req *ht
 
 	var responce models.Metrics
 
-	contentType := req.Header.Get("Content-Type")
+	// contentType := req.Header.Get("Content-Type")
 	// switch contentType {
 	// case "application/json":
 	// 	var request models.Metrics

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,16 +1,18 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
-	"strconv"
 	"text/template"
+
+	"github.com/maryakotova/metrics/internal/models"
 )
 
 const tplPath string = "templates/metrics.html"
 
 type DataStorage interface {
-	SetGauge(key string, value string) (err error)
-	SetCounter(key string, value string) (err error)
+	SetGauge(key string, value float64) (err error)
+	SetCounter(key string, value int64) (err error)
 	GetAll() map[string]interface{}
 	GetAllGauge() map[string]float64
 	GetAllCounter() map[string]int64
@@ -32,76 +34,85 @@ func (server *Server) HandleMetricUpdate(res http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	res.Header().Set("Content-Type", "text/plain")
+	res.Header().Set("Content-Type", "Content-Type: application/json")
 
-	metricType := req.PathValue("metricType")
-	metricName := req.PathValue("metricName")
-	metricValue := req.PathValue("metricValue")
+	var request models.Metrics
+	dec := json.NewDecoder(req.Body)
+	if err := dec.Decode(&request); err != nil {
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	if metricName == "" {
+	if request.ID == "" {
 		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
 		return
 	}
 
-	switch metricType {
+	switch request.MType {
 	case "gauge":
-		err := server.metrics.SetGauge(metricName, metricValue)
-		if err != nil {
-			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
-			return
+		if err := server.metrics.SetGauge(request.ID, *request.Value); err != nil {
+			http.Error(res, "Ошибка при обновлении метрики Gauge", http.StatusBadRequest)
 		}
-
 	case "counter":
-		err := server.metrics.SetCounter(metricName, metricValue)
-		if err != nil {
-			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
-			return
+		if err := server.metrics.SetCounter(request.ID, *request.Delta); err != nil {
+			http.Error(res, "Ошибка при обновлении метрики Counter", http.StatusBadRequest)
 		}
-
 	default:
 		http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
 		return
 	}
 
 	res.WriteHeader(http.StatusOK)
+
 }
 
 func (server *Server) HandleGetOneMetric(res http.ResponseWriter, req *http.Request) {
-	if req.Method != http.MethodGet {
+	if req.Method != http.MethodPost {
 		res.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
 
-	res.Header().Set("Content-Type", "text/plain")
-
-	// switch chi.URLParam(req, "type") { !!!Почему не работает??????
-	switch req.PathValue("metricType") {
-	case "gauge":
-		metricValue, err := server.metrics.GetGauge(req.PathValue("metricName"))
-		if err != nil {
-			http.Error(res, "Запрос неизвестной метрики", http.StatusNotFound)
-			return
-		}
-		res.WriteHeader(http.StatusOK)
-		res.Write([]byte(strconv.FormatFloat(metricValue, 'f', -1, 64)))
-
-	case "counter":
-		metricValue, err := server.metrics.GetCounter(req.PathValue("metricName"))
-		if err != nil {
-			http.Error(res, "Запрос неизвестной метрики", http.StatusNotFound)
-			return
-		}
-		res.WriteHeader(http.StatusOK)
-		res.Write([]byte(strconv.FormatInt(metricValue, 10)))
-
-	case "":
-		http.Error(res, "Тип метрики обязателен для заполнения", http.StatusBadRequest)
-		return
-
-	default:
-		http.Error(res, "Указанный тип метрики не известен", http.StatusNotFound)
+	var request models.Metrics
+	dec := json.NewDecoder(req.Body)
+	if err := dec.Decode(&request); err != nil {
+		res.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
+	responce := models.Metrics{
+		ID:    request.ID,
+		MType: request.MType,
+	}
+
+	switch request.MType {
+	case "gauge":
+		gaugeValue, err := server.metrics.GetGauge(request.ID)
+		if err != nil {
+			http.Error(res, "Запрос неизвестной метрики", http.StatusNotFound)
+			return
+		}
+		responce.Value = &gaugeValue
+	case "counter":
+		counterValue, err := server.metrics.GetCounter(request.ID)
+		if err != nil {
+			http.Error(res, "Запрос неизвестной метрики", http.StatusNotFound)
+			return
+		}
+		responce.Delta = &counterValue
+	default:
+		http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
+		return
+	}
+
+	res.Header().Set("Content-Type", "application/json")
+
+	enc := json.NewEncoder(res)
+	if err := enc.Encode(responce); err != nil {
+		http.Error(res, "Ошибка при заполнении ответа", http.StatusInternalServerError)
+		return
+	}
+	res.WriteHeader(http.StatusOK)
+
 }
 
 func (server *Server) HandleGetAllMetrics(res http.ResponseWriter, req *http.Request) {

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -35,7 +35,6 @@ func (server *Server) HandleMetricUpdateViaJSON(res http.ResponseWriter, req *ht
 		return
 	}
 
-	var responce models.Metrics
 	var request models.Metrics
 
 	dec := json.NewDecoder(req.Body)
@@ -49,8 +48,10 @@ func (server *Server) HandleMetricUpdateViaJSON(res http.ResponseWriter, req *ht
 		return
 	}
 
-	responce.ID = request.ID
-	responce.MType = request.MType
+	responce := models.Metrics{
+		ID:    request.ID,
+		MType: request.MType,
+	}
 
 	switch request.MType {
 	case "gauge":

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -36,11 +36,8 @@ func (server *Server) HandleMetricUpdateViaJSON(res http.ResponseWriter, req *ht
 	}
 
 	var responce models.Metrics
-
-	// contentType := req.Header.Get("Content-Type")
-	// switch contentType {
-	// case "application/json":
 	var request models.Metrics
+
 	dec := json.NewDecoder(req.Body)
 	if err := dec.Decode(&request); err != nil {
 		res.WriteHeader(http.StatusInternalServerError)
@@ -73,60 +70,6 @@ func (server *Server) HandleMetricUpdateViaJSON(res http.ResponseWriter, req *ht
 		return
 	}
 
-	// case "text/plain", "":
-	// metricType := req.PathValue("metricType")
-	// metricName := req.PathValue("metricName")
-	// metricValue := req.PathValue("metricValue")
-
-	// if metricName == "" {
-	// 	http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
-	// 	return
-	// }
-
-	// // responce := models.Metrics{
-	// // 	ID:    metricName,
-	// // 	MType: metricType,
-	// // }
-
-	// responce.ID = metricName
-	// responce.MType = metricType
-
-	// switch metricType {
-	// case "gauge":
-	// 	value, err := strconv.ParseFloat(metricValue, 64)
-	// 	if err != nil {
-	// 		http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
-	// 		return
-	// 	}
-	// 	err = server.metrics.SetGauge(metricName, value)
-	// 	if err != nil {
-	// 		http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
-	// 		return
-	// 	}
-	// 	responce.Value = &value
-
-	// case "counter":
-	// 	value, err := strconv.ParseInt(metricValue, 10, 64)
-	// 	if err != nil {
-	// 		http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
-	// 		return
-	// 	}
-	// 	err = server.metrics.SetCounter(metricName, value)
-	// 	if err != nil {
-	// 		http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
-	// 		return
-	// 	}
-	// 	responce.Delta = &value
-
-	// default:
-	// 	http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
-	// 	return
-	// }
-	// default:
-	// 	http.Error(res, "Неверный формат для обновления метрик (Content-Type)", http.StatusBadRequest)
-	// 	return
-	// }
-
 	res.Header().Set("Content-Type", "Content-Type: application/json")
 
 	enc := json.NewEncoder(res)
@@ -136,7 +79,6 @@ func (server *Server) HandleMetricUpdateViaJSON(res http.ResponseWriter, req *ht
 	}
 
 	res.WriteHeader(http.StatusOK)
-
 }
 
 func (server *Server) HandleMetricUpdate(res http.ResponseWriter, req *http.Request) {

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -40,88 +40,88 @@ func (server *Server) HandleMetricUpdateViaJSON(res http.ResponseWriter, req *ht
 	// contentType := req.Header.Get("Content-Type")
 	// switch contentType {
 	// case "application/json":
-	// 	var request models.Metrics
-	// 	dec := json.NewDecoder(req.Body)
-	// 	if err := dec.Decode(&request); err != nil {
-	// 		res.WriteHeader(http.StatusInternalServerError)
-	// 		return
-	// 	}
+	var request models.Metrics
+	dec := json.NewDecoder(req.Body)
+	if err := dec.Decode(&request); err != nil {
+		res.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	// 	if request.ID == "" {
-	// 		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
-	// 		return
-	// 	}
-
-	// 	responce.ID = request.ID
-	// 	responce.MType = request.MType
-
-	// 	switch request.MType {
-	// 	case "gauge":
-	// 		if err := server.metrics.SetGauge(request.ID, *request.Value); err != nil {
-	// 			http.Error(res, "Ошибка при обновлении метрики Gauge", http.StatusBadRequest)
-	// 			return
-	// 		}
-	// 		responce.Value = request.Value
-	// 	case "counter":
-	// 		if err := server.metrics.SetCounter(request.ID, *request.Delta); err != nil {
-	// 			http.Error(res, "Ошибка при обновлении метрики Counter", http.StatusBadRequest)
-	// 			return
-	// 		}
-	// 		responce.Delta = request.Delta
-	// 	default:
-	// 		http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
-	// 		return
-	// 	}
-
-	// case "text/plain", "":
-	metricType := req.PathValue("metricType")
-	metricName := req.PathValue("metricName")
-	metricValue := req.PathValue("metricValue")
-
-	if metricName == "" {
+	if request.ID == "" {
 		http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
 		return
 	}
 
-	// responce := models.Metrics{
-	// 	ID:    metricName,
-	// 	MType: metricType,
-	// }
+	responce.ID = request.ID
+	responce.MType = request.MType
 
-	responce.ID = metricName
-	responce.MType = metricType
-
-	switch metricType {
+	switch request.MType {
 	case "gauge":
-		value, err := strconv.ParseFloat(metricValue, 64)
-		if err != nil {
-			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
+		if err := server.metrics.SetGauge(request.ID, *request.Value); err != nil {
+			http.Error(res, "Ошибка при обновлении метрики Gauge", http.StatusBadRequest)
 			return
 		}
-		err = server.metrics.SetGauge(metricName, value)
-		if err != nil {
-			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
-			return
-		}
-		responce.Value = &value
-
+		responce.Value = request.Value
 	case "counter":
-		value, err := strconv.ParseInt(metricValue, 10, 64)
-		if err != nil {
-			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
+		if err := server.metrics.SetCounter(request.ID, *request.Delta); err != nil {
+			http.Error(res, "Ошибка при обновлении метрики Counter", http.StatusBadRequest)
 			return
 		}
-		err = server.metrics.SetCounter(metricName, value)
-		if err != nil {
-			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
-			return
-		}
-		responce.Delta = &value
-
+		responce.Delta = request.Delta
 	default:
 		http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
 		return
 	}
+
+	// case "text/plain", "":
+	// metricType := req.PathValue("metricType")
+	// metricName := req.PathValue("metricName")
+	// metricValue := req.PathValue("metricValue")
+
+	// if metricName == "" {
+	// 	http.Error(res, "Невозможно обновить метрику(пустое имя или значение метрики)", http.StatusNotFound)
+	// 	return
+	// }
+
+	// // responce := models.Metrics{
+	// // 	ID:    metricName,
+	// // 	MType: metricType,
+	// // }
+
+	// responce.ID = metricName
+	// responce.MType = metricType
+
+	// switch metricType {
+	// case "gauge":
+	// 	value, err := strconv.ParseFloat(metricValue, 64)
+	// 	if err != nil {
+	// 		http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
+	// 		return
+	// 	}
+	// 	err = server.metrics.SetGauge(metricName, value)
+	// 	if err != nil {
+	// 		http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
+	// 		return
+	// 	}
+	// 	responce.Value = &value
+
+	// case "counter":
+	// 	value, err := strconv.ParseInt(metricValue, 10, 64)
+	// 	if err != nil {
+	// 		http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
+	// 		return
+	// 	}
+	// 	err = server.metrics.SetCounter(metricName, value)
+	// 	if err != nil {
+	// 		http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
+	// 		return
+	// 	}
+	// 	responce.Delta = &value
+
+	// default:
+	// 	http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
+	// 	return
+	// }
 	// default:
 	// 	http.Error(res, "Неверный формат для обновления метрик (Content-Type)", http.StatusBadRequest)
 	// 	return

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,82 @@
+package logger
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+var Log *zap.Logger = zap.NewNop()
+
+type (
+	responseData struct {
+		status int
+		size   int
+	}
+
+	loggingResponseWriter struct {
+		http.ResponseWriter
+		responseData *responseData
+	}
+)
+
+func Initialize(level string) error {
+
+	if level == "" {
+		level = "info"
+	}
+
+	lvl, err := zap.ParseAtomicLevel(level)
+	if err != nil {
+		return err
+	}
+	cfg := zap.NewProductionConfig()
+	cfg.Level = lvl
+	zl, err := cfg.Build()
+	if err != nil {
+		return err
+	}
+	Log = zl
+	return nil
+}
+
+func (r *loggingResponseWriter) Write(b []byte) (int, error) {
+	size, err := r.ResponseWriter.Write(b)
+	r.responseData.size += size
+	return size, err
+}
+
+func (r *loggingResponseWriter) WriteHeader(statusCode int) {
+	r.ResponseWriter.WriteHeader(statusCode)
+	r.responseData.status = statusCode
+}
+
+func WithLogging(h http.HandlerFunc) http.HandlerFunc {
+	// return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		responseData := &responseData{
+			status: 0,
+			size:   0,
+		}
+		lw := loggingResponseWriter{
+			ResponseWriter: w,
+			responseData:   responseData,
+		}
+
+		h(&lw, r)
+
+		duration := time.Since(start)
+
+		Log.Info("got incoming HTTP request",
+			zap.String("uri", r.RequestURI),
+			zap.String("method", r.Method),
+			zap.String("duration", duration.String()),
+			zap.String("status", strconv.Itoa(responseData.status)),
+			zap.String("size", strconv.Itoa(responseData.size)),
+		)
+	}
+}

--- a/internal/logic/logic.go
+++ b/internal/logic/logic.go
@@ -1,33 +1,55 @@
 package logic
 
-// import "net/http"
+// import (
+// 	"fmt"
+// 	"net/http"
+// 	"strconv"
 
-// func UpdateMetric(metricType string, metricName string, metricValue string) (errorText string, code int) {
+// 	"github.com/maryakotova/metrics/internal/models"
+// )
+
+// func MetricUpdate(metricType string, metricName string, metricValue string) (responce models.Metrics, err error, status int) {
+
 // 	if metricName == "" {
-// 		errorText = "Невозможно обновить метрику(пустое имя или значение метрики"
-// 		code = http.StatusNotFound
+// 		err = fmt.Errorf("Невозможно обновить метрику(пустое имя или значение метрики)")
+// 		status = http.StatusNotFound
 // 		return
 // 	}
 
+// 	responce.ID = metricName
+// 	responce.MType = metricType
+
 // 	switch metricType {
 // 	case "gauge":
-// 		err := server.metrics.SetGauge(metricName, metricValue)
+// 		value, er := strconv.ParseFloat(metricValue, 64)
+// 		if er != nil {
+// 			err = fmt.Errorf("Неверный формат значения для обновления метрики Gauge")
+// 			status = http.StatusBadRequest
+// 			return
+// 		}
+// 		er = server.metrics.SetGauge(metricName, value)
 // 		if err != nil {
 // 			http.Error(res, "Неверный формат значения для обновления метрики Gauge", http.StatusBadRequest)
 // 			return
 // 		}
+// 		responce.Value = &value
 
 // 	case "counter":
-// 		err := server.metrics.SetCounter(metricName, metricValue)
+// 		value, err := strconv.ParseInt(metricValue, 10, 64)
 // 		if err != nil {
 // 			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
 // 			return
 // 		}
+// 		err = server.metrics.SetCounter(metricName, value)
+// 		if err != nil {
+// 			http.Error(res, "Неверный формат значения для обновления метрик Counter", http.StatusBadRequest)
+// 			return
+// 		}
+// 		responce.Delta = &value
 
 // 	default:
 // 		http.Error(res, "Неверный формат для обновления метрик (неверный тип)", http.StatusBadRequest)
 // 		return
 // 	}
 
-// 	return
 // }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,0 +1,8 @@
+package models
+
+type Metrics struct {
+	ID    string   `json:"id"`              // имя метрики
+	MType string   `json:"type"`            // параметр, принимающий значение gauge или counter
+	Delta *int64   `json:"delta,omitempty"` // значение метрики в случае передачи counter
+	Value *float64 `json:"value,omitempty"` // значение метрики в случае передачи gauge
+}

--- a/internal/sender/sender.go
+++ b/internal/sender/sender.go
@@ -74,12 +74,12 @@ func SendMetric(serverAddress string, metricType string, metricName string, metr
 
 	defer resp.Body.Close()
 
-	switch metricType {
-	case "gauge":
-		fmt.Printf("Sent metric: %s/%s/%v -/%v, response status: %s\n", metricType, metricName, floatValue, *metricForSend.Value, resp.Status)
-	case "counter":
-		fmt.Printf("Sent metric: %s/%s/%v -/%v, response status: %s\n", metricType, metricName, intValue, *metricForSend.Delta, resp.Status)
-	}
+	// switch metricType {
+	// case "gauge":
+	// 	fmt.Printf("Sent metric: %s/%s/%v -/%v, response status: %s\n", metricType, metricName, floatValue, *metricForSend.Value, resp.Status)
+	// case "counter":
+	// 	fmt.Printf("Sent metric: %s/%s/%v -/%v, response status: %s\n", metricType, metricName, intValue, *metricForSend.Delta, resp.Status)
+	// }
 
 	return nil
 

--- a/internal/sender/sender.go
+++ b/internal/sender/sender.go
@@ -64,7 +64,7 @@ func SendMetric(serverAddress string, metricType string, metricName string, metr
 		return err
 	}
 
-	url := fmt.Sprintf("http://%s/update/", serverAddress)
+	url := fmt.Sprintf("http://%s/update/%s/%s/%v", serverAddress, metricType, metricName, metricValue)
 
 	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {

--- a/internal/sender/sender.go
+++ b/internal/sender/sender.go
@@ -1,28 +1,86 @@
 package sender
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/maryakotova/metrics/internal/models"
 )
 
 func SendMetric(serverAddress string, metricType string, metricName string, metricValue interface{}) error {
-	url := fmt.Sprintf("http://%s/update/%s/%s/%v", serverAddress, metricType, metricName, metricValue)
-	req, err := http.NewRequest("POST", url, nil)
+
+	metricForSend := models.Metrics{
+		ID:    metricName,
+		MType: metricType,
+	}
+
+	var floatValue float64
+	var intValue int64
+
+	switch metricType {
+	case "gauge":
+		switch v := metricValue.(type) {
+		case int:
+			floatValue = float64(v)
+		case int8:
+			floatValue = float64(v)
+		case int16:
+			floatValue = float64(v)
+		case int32:
+			floatValue = float64(v)
+		case int64:
+			floatValue = float64(v)
+		case uint:
+			floatValue = float64(v)
+		case uint8:
+			floatValue = float64(v)
+		case uint16:
+			floatValue = float64(v)
+		case uint32:
+			floatValue = float64(v)
+		case uint64:
+			floatValue = float64(v)
+		case float32:
+			floatValue = float64(v)
+		case float64:
+			floatValue = v
+		}
+
+	case "counter":
+		switch v := metricValue.(type) {
+		case int64:
+			intValue = v
+		}
+	}
+
+	metricForSend.Delta = &intValue
+	metricForSend.Value = &floatValue
+
+	jsonData, err := json.Marshal(metricForSend)
 	if err != nil {
-		fmt.Println("Error creating request:", err)
+		fmt.Printf("Error marshaling JSON: %v\n:", err)
 		return err
 	}
 
-	req.Header.Set("Content-Type", "text/plain")
+	url := fmt.Sprintf("http://%s/update/", serverAddress)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
-
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
-		fmt.Println("Error sending metric:", err)
+		fmt.Printf("Error sending request: %v\n", err)
 		return err
 	}
+
 	defer resp.Body.Close()
-	fmt.Printf("Sent metric: %s/%s/%v\n", metricType, metricName, metricValue)
-	return err
+
+	switch metricType {
+	case "gauge":
+		fmt.Printf("Sent metric: %s/%s/%v -/%v, response status: %s\n", metricType, metricName, floatValue, *metricForSend.Value, resp.Status)
+	case "counter":
+		fmt.Printf("Sent metric: %s/%s/%v -/%v, response status: %s\n", metricType, metricName, intValue, *metricForSend.Delta, resp.Status)
+	}
+
+	return nil
+
 }

--- a/internal/sender/sender.go
+++ b/internal/sender/sender.go
@@ -64,7 +64,8 @@ func SendMetric(serverAddress string, metricType string, metricName string, metr
 		return err
 	}
 
-	url := fmt.Sprintf("http://%s/update/%s/%s/%v", serverAddress, metricType, metricName, metricValue)
+	// url := fmt.Sprintf("http://%s/update/%s/%s/%v", serverAddress, metricType, metricName, metricValue)
+	url := fmt.Sprintf("http://%s/update/", serverAddress)
 
 	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {

--- a/internal/sender/sender_test.go
+++ b/internal/sender/sender_test.go
@@ -1,0 +1,144 @@
+package sender
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSendMetric_SuccessGauge(t *testing.T) {
+	// Создаем тестовый сервер, который будет имитировать успешный ответ на POST запрос
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Проверим, что запрос это POST
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+
+		// Ответим успешным кодом и без тела
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Подготовим данные для запроса
+	serverAddress := ts.URL[len("http://"):]
+	metricType := "Test1"
+	metricName := "gauge"
+	metricValue := 45.67
+
+	// Выполним вызов функции SendMetric
+	err := SendMetric(serverAddress, metricType, metricName, metricValue)
+
+	// Проверим, что ошибок нет
+	assert.NoError(t, err)
+}
+
+func TestSendMetric_SuccessCounter(t *testing.T) {
+	// Создаем тестовый сервер, который будет имитировать успешный ответ на POST запрос
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Проверим, что запрос это POST
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+
+		// Ответим успешным кодом и без тела
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Подготовим данные для запроса
+	serverAddress := ts.URL[len("http://"):]
+	metricType := "Test2"
+	metricName := "counter"
+	metricValue := "asd"
+
+	// Выполним вызов функции SendMetric
+	err := SendMetric(serverAddress, metricType, metricName, metricValue)
+
+	// Проверим, что ошибок нет
+	assert.NoError(t, err)
+}
+
+//не подходит, так как нужно проверять ответ сервера
+// func TestSendMetric(t *testing.T) {
+// 	type args struct {
+// 		serverAddress string
+// 		metricType    string
+// 		metricName    string
+// 		metricValue   interface{}
+// 	}
+// 	tests := []struct {
+// 		name    string
+// 		args    args
+// 		wantErr bool
+// 	}{
+// 		{
+// 			name: "test gauge",
+// 			args: args{
+// 				serverAddress: "localhost:8080",
+// 				metricType:    "gauge",
+// 				metricName:    "Test1",
+// 				metricValue:   123.456,
+// 			},
+// 			wantErr: false,
+// 		},
+// 		{
+// 			name: "test gauge with -",
+// 			args: args{
+// 				serverAddress: "localhost:8080",
+// 				metricType:    "gauge",
+// 				metricName:    "Test2",
+// 				metricValue:   -123.456,
+// 			},
+// 			wantErr: false,
+// 		},
+// 		{
+// 			name: "test gauge with error",
+// 			args: args{
+// 				serverAddress: "localhost:8080",
+// 				metricType:    "gauge",
+// 				metricName:    "Test3",
+// 				metricValue:   "abc",
+// 			},
+// 			wantErr: false,
+// 		},
+// 		{
+// 			name: "test counter",
+// 			args: args{
+// 				serverAddress: "localhost:8080",
+// 				metricType:    "counter",
+// 				metricName:    "Test4",
+// 				metricValue:   33,
+// 			},
+// 			wantErr: false,
+// 		},
+// 		{
+// 			name: "test counter with -",
+// 			args: args{
+// 				serverAddress: "localhost:8080",
+// 				metricType:    "counter",
+// 				metricName:    "Test4",
+// 				metricValue:   -10,
+// 			},
+// 			wantErr: false,
+// 		},
+// 		{
+// 			name: "test counter with error",
+// 			args: args{
+// 				serverAddress: "localhost:8080",
+// 				metricType:    "counter",
+// 				metricName:    "Test4",
+// 				metricValue:   321.456,
+// 			},
+// 			wantErr: false,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			if err := SendMetric(tt.args.serverAddress, tt.args.metricType, tt.args.metricName, tt.args.metricValue); (err != nil) != tt.wantErr {
+// 				t.Errorf("SendMetric() error = %v, wantErr %v", err, tt.wantErr)
+// 			}
+// 		})
+// 	}
+// }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -29,17 +29,17 @@ func (ms *MemStorage) strValueToFloat(str string) (value float64, err error) {
 	return
 }
 
-func (ms *MemStorage) SetGauge(key string, value string) (err error) {
+func (ms *MemStorage) SetGauge(key string, value float64) (err error) {
 	if key == "" {
 		err = fmt.Errorf("имя метрики обязательно для заполнения")
 		return
 	}
-	floatValue, err := ms.strValueToFloat(value)
-	if err != nil {
-		return err
-	}
+	// floatValue, err := ms.strValueToFloat(value)
+	// if err != nil {
+	// 	return err
+	// }
 
-	ms.gauge[key] = floatValue
+	ms.gauge[key] = value
 	return
 }
 
@@ -48,22 +48,22 @@ func (ms *MemStorage) strValueToInt(str string) (value int64, err error) {
 	return
 }
 
-func (ms *MemStorage) SetCounter(key string, value string) (err error) {
+func (ms *MemStorage) SetCounter(key string, value int64) (err error) {
 	if key == "" {
 		err = fmt.Errorf("имя метрики обязательно для заполнения")
 		return
 	}
-	intValue, err := ms.strValueToInt(value)
-	if err != nil {
-		return err
-	}
+	// intValue, err := ms.strValueToInt(value)
+	// if err != nil {
+	// 	return err
+	// }
 
 	_, ok := ms.counter[key]
 	if ok {
-		ms.counter[key] += intValue
+		ms.counter[key] += value
 
 	} else {
-		ms.counter[key] = intValue
+		ms.counter[key] = value
 	}
 	return
 }


### PR DESCRIPTION
Дополнен API сервера, чтобы позволить ему принимать метрики в формате JSON.
При реализации задействована библиотека encoding/jsonю
Для передачи метрик на сервер используйте Content-Type: application/json. В теле запроса должен быть описанный выше JSON. Передавать метрики нужно через POST update/. В теле ответа отправляйте JSON той же структуры с актуальным (изменённым) значением Value. 
Для получения метрик с сервера также используйте Content-Type: application/json. В теле запроса должен быть описанный выше JSON с заполненными полями ID и MType. Запрашивать нужно через POST value/. В теле ответа должен приходить такой же JSON, но с уже заполненными значениями метрик. 
