### PR TITLE
Iter24

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -20,6 +20,7 @@ type Agent struct {
 	sendQueue      chan Metrics
 	resultQueue    chan Result
 	publicKeyPath  string
+	realIP         string
 }
 
 func New(cfg *Config) *Agent {
@@ -37,5 +38,6 @@ func New(cfg *Config) *Agent {
 		sendQueue:     make(chan Metrics, cfg.RateLimit),
 		resultQueue:   make(chan Result, cfg.RateLimit),
 		publicKeyPath: cfg.PublicCryptoKey,
+		realIP:        cfg.RealIP,
 	}
 }

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	PublicCryptoKey string //`env:"CRYPTO_KEY"`
 	ConfigPath      string //`env:CONFIG`
 	ConfigPathShort string
+	// не знаю, как еще можно получить IP адрес агента, поэтому решила использовать переменные окружения и флаги
+	RealIP string //`env:REAL_IP`
 }
 
 func ParseFlags() (*Config, error) {
@@ -33,7 +35,8 @@ func ParseFlags() (*Config, error) {
 	flag.IntVar(&cfg.RateLimit, "l", 4, "Количество одновременно исходящих запросов на сервер")
 	flag.StringVar(&cfg.PublicCryptoKey, "crypto-key", "", "Путь до файла с публичным ключом") //./key/cert.pem
 	flag.StringVar(&cfg.ConfigPath, "config", "", "конфигурации сервера с помощью файла в формате JSON")
-	flag.StringVar(&cfg.ConfigPath, "c", "", "конфигурации сервера с помощью файла в формате JSON(shorthand)")
+	flag.StringVar(&cfg.ConfigPathShort, "c", "", "конфигурации сервера с помощью файла в формате JSON(shorthand)")
+	flag.StringVar(&cfg.RealIP, "i", "", "IP адрес агента для заполнения заголовка X-Real-IP")
 
 	//аргументы командной строки
 	flag.Parse()
@@ -100,6 +103,10 @@ func ParseFlags() (*Config, error) {
 		cfg.PublicCryptoKey = publicKey
 	} else if cfg.PublicCryptoKey != "" && agentConfig.CryptoKey != "" {
 		cfg.PublicCryptoKey = agentConfig.CryptoKey
+	}
+
+	if realIP := os.Getenv("REAL_IP"); realIP != "" {
+		cfg.RealIP = realIP
 	}
 
 	return &cfg, nil

--- a/internal/agent/sender.go
+++ b/internal/agent/sender.go
@@ -123,69 +123,13 @@ func (agent *Agent) doUpdatesRequest(metrics []models.MetricsForSend) error {
 	return nil
 }
 
-// 	jsonData, err := json.Marshal(&batch)
-// 	if err != nil {
-// 		return fmt.Errorf("failed to marshal data: %w", err)
-// 	}
-// 	var hash string
-// 	if agent.SecretKey != "" {
-// 		hash = authsign.CalculateHash(jsonData, []byte(agent.SecretKey))
-// 	}
-
-// 	if agent.publicKeyPath != "" {
-// 		jsonData, err = cryptoutil.EncrypteBody(jsonData, agent.publicKeyPath)
-// 		if err != nil {
-// 			return fmt.Errorf("failed toencrypte body: %w", err)
-// 		}
-// 	}
-
-// 	var buf bytes.Buffer
-// 	gzipWriter := gzip.NewWriter(&buf)
-
-// 	_, err = gzipWriter.Write(jsonData)
-// 	if err != nil {
-// 		return fmt.Errorf("failed to write to gzip writer: %w", err)
-// 	}
-
-// 	if err := gzipWriter.Close(); err != nil {
-// 		return fmt.Errorf("failed to close gzip writer: %w", err)
-// 	}
-
-// 	url := fmt.Sprintf("http://%s/updates/", agent.ServerAddress)
-
-// 	request, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(buf.Bytes()))
-// 	if err != nil {
-// 		fmt.Println("Error sending request: %w\n", err)
-// 		return err
-// 	}
-
-// 	request.Header.Set("Content-Encoding", "gzip")
-// 	request.Header.Set("Accept-Encoding", "")
-// 	if hash != "" {
-// 		request.Header.Set(constants.HeaderSig, hash)
-// 	}
-// 	if agent.publicKeyPath != "" {
-// 		request.Header.Set("Content-Encrypted", "true")
-// 	}
-
-// 	resp, err := http.DefaultClient.Do(request)
-// 	if err != nil {
-// 		fmt.Println("Error sending request: %w\n", err)
-// 		return err
-// 	}
-
-// 	defer resp.Body.Close()
-
-// }
-// return nil
-// }
-
 func isRetriableError(err error) bool {
 	var opErr *net.OpError
 	return errors.As(err, &opErr)
 }
 
 func (agent *Agent) SendRequest(metrics []models.MetricsForSend) error {
+
 	jsonData, err := json.Marshal(&metrics)
 	if err != nil {
 		return fmt.Errorf("failed to marshal data: %w", err)
@@ -220,6 +164,10 @@ func (agent *Agent) SendRequest(metrics []models.MetricsForSend) error {
 	if err != nil {
 		fmt.Println("Error sending request: %w\n", err)
 		return err
+	}
+
+	if agent.realIP != "" {
+		request.Header.Set("X-Real-IP", agent.realIP)
 	}
 
 	request.Header.Set("Content-Encoding", "gzip")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Database       DatabaseConfig
 	SecretKey      string
 	PrivateKeyPath string
+	TrustedSubnet  string
 }
 
 // ServerConfig- серверная часть настроек.
@@ -43,6 +44,7 @@ func NewConfig(flags *Flags) *Config {
 		},
 		SecretKey:      flags.SecretKey,
 		PrivateKeyPath: flags.PrivateCryptoKey,
+		TrustedSubnet:  flags.TrustedSubnet,
 	}
 }
 

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -28,8 +28,9 @@ type Flags struct {
 	}
 	SecretKey        string //`env:"KEY"`
 	PrivateCryptoKey string //`env:"CRYPTO_KEY"`
-	ConfigPath       string //`env:CONFIG`
+	ConfigPath       string //`env:"CONFIG"`
 	ConfigPathShort  string
+	TrustedSubnet    string //`env:"TRUSTED_SUBNET"`
 }
 
 // В функции ParseFlags происходит парсинг аргументов командной строки и получение значений из переменных окружения.
@@ -46,7 +47,8 @@ func ParseFlags() (*Flags, error) {
 	flag.StringVar(&flags.SecretKey, "k", "", "Ключ для подписи передаваемых данных")
 	flag.StringVar(&flags.PrivateCryptoKey, "crypto-key", "", "Путь до файла с приватным ключом") //./key/private_key.pem
 	flag.StringVar(&flags.ConfigPath, "config", "", "конфигурации сервера с помощью файла в формате JSON")
-	flag.StringVar(&flags.ConfigPath, "c", "", "конфигурации сервера с помощью файла в формате JSON(shorthand)")
+	flag.StringVar(&flags.ConfigPathShort, "c", "", "конфигурации сервера с помощью файла в формате JSON(shorthand)")
+	flag.StringVar(&flags.TrustedSubnet, "t", "", "строковое представление бесклассовой адресации (CIDR) для проверки IP клиента")
 
 	//аргументы командной строки
 	flag.Parse()
@@ -103,7 +105,7 @@ func ParseFlags() (*Flags, error) {
 
 	if envDSN := os.Getenv("DATABASE_DSN"); envDSN != "" {
 		flags.Database.DatabaseDsn = envDSN
-	} else if flags.Database.DatabaseDsn != "" && serverConfig.DatabaseDSN != "" {
+	} else if flags.Database.DatabaseDsn == "" && serverConfig.DatabaseDSN != "" {
 		flags.Database.DatabaseDsn = serverConfig.DatabaseDSN
 	}
 
@@ -113,8 +115,14 @@ func ParseFlags() (*Flags, error) {
 
 	if privateKey := os.Getenv("CRYPTO_KEY"); privateKey != "" {
 		flags.PrivateCryptoKey = privateKey
-	} else if flags.PrivateCryptoKey != "" && serverConfig.CryptoKey != "" {
+	} else if flags.PrivateCryptoKey == "" && serverConfig.CryptoKey != "" {
 		flags.PrivateCryptoKey = serverConfig.CryptoKey
+	}
+
+	if trustedSubnet := os.Getenv("TRUSTED_SUBNETY"); trustedSubnet != "" {
+		flags.TrustedSubnet = trustedSubnet
+	} else if flags.TrustedSubnet == "" && serverConfig.TrustedSubnet != "" {
+		flags.TrustedSubnet = serverConfig.TrustedSubnet
 	}
 
 	return &flags, nil

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,6 +1,8 @@
 // В пакете constants хранятся глобальные константы.
 package constants
 
+import "time"
+
 const (
 	Gauge                        = "gauge"
 	Counter                      = "counter"
@@ -13,4 +15,5 @@ const (
 	DefaultStoreFile             = "./metricsStorage.json"
 	DefaultReportInterval int64  = 5
 	DefaultPollInterval   int64  = 2
+	ShutdownTimeout              = 5 * time.Second
 )

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -25,6 +25,7 @@ type JSONConfigServer struct {
 	StoreFile     string `json:"store_file"`     // аналог переменной окружения STORE_FILE или -f
 	DatabaseDSN   string `json:"database_dsn"`   // аналог переменной окружения DATABASE_DSN или флага -d
 	CryptoKey     string `json:"crypto_key"`     // аналог переменной окружения CRYPTO_KEY или флага -crypto-key
+	TrustedSubnet string `json:"trusted_subnet"` // аналог переменной окружения TRUSTED_SUBNET или флага -t
 }
 
 // Конфигурации агента с помощью файла в формате JSON

--- a/internal/trustedip/trustedip.go
+++ b/internal/trustedip/trustedip.go
@@ -1,0 +1,58 @@
+package trustedip
+
+import (
+	"metrics/internal/config"
+	"net"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+type CheckIPMiddleware struct {
+	config *config.Config
+	logger *zap.Logger
+	ipNet  *net.IPNet
+}
+
+func NewCheckIPMW(cfg *config.Config, logger *zap.Logger) *CheckIPMiddleware {
+	ipmw := &CheckIPMiddleware{
+		config: cfg,
+		logger: logger,
+	}
+
+	if cfg.TrustedSubnet != "" {
+		_, ipNet, err := net.ParseCIDR(cfg.TrustedSubnet)
+		if err != nil {
+			//error
+		} else {
+			ipmw.ipNet = ipNet
+		}
+	}
+
+	return ipmw
+}
+
+func (chip *CheckIPMiddleware) CheckIP(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ow := w
+
+		if chip.ipNet != nil {
+			// получить IP адрес из заголовка
+			ipStr := r.Header.Get("X-Real-IP")
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				http.Error(w, "неверный IP адрес", http.StatusForbidden)
+				return
+			}
+
+			// проверить входит ли полученный IP адрес в список доверенных
+			if !chip.ipNet.Contains(ip) {
+				http.Error(w, "неверный IP адрес", http.StatusForbidden)
+				return
+			}
+
+		}
+
+		h.ServeHTTP(ow, r)
+	}
+}


### PR DESCRIPTION
Добавьте в конфигурационный JSON-файл сервера поле trusted_subnet (тип string, переменная окружения TRUSTED_SUBNET, флаг -t), в которое можно передать строковое представление бесклассовой адресации (CIDR).
Добавьте в запрос агента заголовок X-Real-IP, в котором должен содержаться IP-адрес хоста агента.
При отправке метрик агентом серверу нужно проверять, что переданный в заголовке запроса X-Real-IP IP-адрес агента входит в доверенную подсеть, в противном случае возвращать статус ответа 403 Forbidden.
При пустом значении переменной trusted_subnet метрики должны обрабатываться сервером без дополнительных ограничений.